### PR TITLE
feat: mica backdrop on windows 11

### DIFF
--- a/internal/desktop/backdrop_other.go
+++ b/internal/desktop/backdrop_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package desktop
+
+// Mica is a Windows 11 window material, so there is nothing to ask for
+// anywhere else.
+func supportsMica() bool {
+	return false
+}

--- a/internal/desktop/backdrop_windows.go
+++ b/internal/desktop/backdrop_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package desktop
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// micaMinBuild is the first Windows 11 build with DWM system backdrops. Below
+// it there is no Mica to ask for.
+const micaMinBuild = 22621
+
+// osVersionInfo mirrors RTL_OSVERSIONINFOW. GetVersionEx lies about the build
+// on anything without a matching app manifest, so RtlGetVersion is the only
+// reading worth trusting here.
+type osVersionInfo struct {
+	osVersionInfoSize uint32
+	majorVersion      uint32
+	minorVersion      uint32
+	buildNumber       uint32
+	platformID        uint32
+	csdVersion        [128]uint16
+}
+
+// supportsMica reports whether this Windows can draw the Mica material.
+func supportsMica() bool {
+	proc := syscall.NewLazyDLL("ntdll.dll").NewProc("RtlGetVersion")
+	if err := proc.Find(); err != nil {
+		return false
+	}
+	var info osVersionInfo
+	info.osVersionInfoSize = uint32(unsafe.Sizeof(info))
+	if ret, _, _ := proc.Call(uintptr(unsafe.Pointer(&info))); ret != 0 {
+		return false
+	}
+	return info.majorVersion > 10 ||
+		(info.majorVersion == 10 && info.buildNumber >= micaMinBuild)
+}

--- a/internal/desktop/run.go
+++ b/internal/desktop/run.go
@@ -112,6 +112,14 @@ func Run(cfg Config) error {
 		},
 		Windows: &wailswindows.Options{
 			Theme: wailswindows.SystemDefault,
+			// Mica is the material a native Windows 11 window is made of, and
+			// the caption bar picks it up instead of staying a flat grey slab.
+			// wails only reads BackdropType when WindowIsTranslucent is set, and
+			// on Windows 10 that same flag means something else entirely (a
+			// blur-behind over the whole window), so it is only asked for where
+			// the backdrop actually exists.
+			WindowIsTranslucent: supportsMica(),
+			BackdropType:        wailswindows.Mica,
 		},
 		Bind: []interface{}{
 			app,


### PR DESCRIPTION
Closes #250.

Windows only had `Theme: SystemDefault`, so the window was a plain frame with a flat grey caption. Now it asks DWM for Mica, the material native Windows 11 apps are made of.

Two things I hit reading how wails applies it.

Wails only reads `BackdropType` when `WindowIsTranslucent` is set, so that flag has to go on too. But on Windows 10 the same flag means something else: below build 22621 wails calls `SetTranslucentBackground`, which is blur behind over the whole window rather than Mica. Turning it on unconditionally would have changed how Windows 10 looks for no gain.

So there is a version gate. Wails does not expose one, so it is an RtlGetVersion call in a windows-only file, gated to build 22621 and up. GetVersionEx lies about the build number without a matching app manifest, which is why it is not that. No new dependency, syscall from the standard library, and a `!windows` stub returning false.

What this does and does not do: Pelton paints every surface opaque, so Mica shows in the caption bar that DWM draws, not in the client area. Getting it behind the content needs semi transparent surfaces, which fights the theme system, same reason translucency was dropped for macOS in #234. This is a title bar change.

go build, go vet and go test pass, and it cross compiles clean with GOOS=windows for both build and vet, so the syscall path is at least type correct.

I have no Windows machine, so nothing here is verified by running. Needs a check on Windows 11 (Mica on the caption) and on Windows 10 (nothing should change at all, that is the one I would actually worry about).
